### PR TITLE
Add new redis connection rate limit to better handle request spikes

### DIFF
--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -69,7 +69,7 @@ func (this *poolImpl) Put(c Connection) {
 	}
 }
 
-func NewPoolImpl(scope stats.Scope, useTls bool, auth string, url string, poolSize int, overflowPoolSize int, overflowDrainPeriod time.Duration, maxNewConnPerSecond int) Pool {
+func NewPoolImpl(scope stats.Scope, useTls bool, auth string, url string, poolSize int, overflowPoolSize int, overflowDrainPeriod time.Duration, maxNewConnPerSecond int, getTimeout time.Duration) Pool {
 	logger.Warnf("connecting to redis on %s with pool size %d", url, poolSize)
 	df := func(network, addr string) (*redis.Client, error) {
 		var conn net.Conn
@@ -96,14 +96,18 @@ func NewPoolImpl(scope stats.Scope, useTls bool, auth string, url string, poolSi
 		}
 		return client, nil
 	}
+
 	var opts []pool.Opt
 	if overflowPoolSize > 0 {
 		opts = append(opts, pool.OnFullBuffer(overflowPoolSize, overflowDrainPeriod))
 	}
-
+	if getTimeout > 0 {
+		opts = append(opts, pool.GetTimeout(getTimeout))
+	}
 	if maxNewConnPerSecond > 0 {
 		opts = append(opts, pool.CreateLimit(0, time.Second/time.Duration(maxNewConnPerSecond)))
 	}
+
 	pool, err := pool.NewCustom("tcp", url, poolSize, df, opts...)
 	checkError(err)
 

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -51,10 +51,10 @@ func (runner *Runner) Run() {
 
 	var perSecondPool redis.Pool
 	if s.RedisPerSecond {
-		perSecondPool = redis.NewPoolImpl(srv.Scope().Scope("redis_per_second_pool"), s.RedisPerSecondTls, s.RedisPerSecondAuth, s.RedisPerSecondUrl, s.RedisPerSecondPoolSize, s.RedisPoolOverflowSize, s.RedisPoolOverflowDrainPeriod, s.RedisPoolMaxNewConnPerSecond)
+		perSecondPool = redis.NewPoolImpl(srv.Scope().Scope("redis_per_second_pool"), s.RedisPerSecondTls, s.RedisPerSecondAuth, s.RedisPerSecondUrl, s.RedisPerSecondPoolSize, s.RedisPoolOverflowSize, s.RedisPoolOverflowDrainPeriod, s.RedisPoolMaxNewConnPerSecond, s.RedisPoolGetTimeout)
 	}
 	var otherPool redis.Pool
-	otherPool = redis.NewPoolImpl(srv.Scope().Scope("redis_pool"), s.RedisTls, s.RedisAuth, s.RedisUrl, s.RedisPoolSize, s.RedisPoolOverflowSize, s.RedisPoolOverflowDrainPeriod, s.RedisPoolMaxNewConnPerSecond)
+	otherPool = redis.NewPoolImpl(srv.Scope().Scope("redis_pool"), s.RedisTls, s.RedisAuth, s.RedisUrl, s.RedisPoolSize, s.RedisPoolOverflowSize, s.RedisPoolOverflowDrainPeriod, s.RedisPoolMaxNewConnPerSecond, s.RedisPoolGetTimeout)
 
 	service := ratelimit.NewService(
 		srv.Runtime(),

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -51,10 +51,10 @@ func (runner *Runner) Run() {
 
 	var perSecondPool redis.Pool
 	if s.RedisPerSecond {
-		perSecondPool = redis.NewPoolImpl(srv.Scope().Scope("redis_per_second_pool"), s.RedisPerSecondTls, s.RedisPerSecondAuth, s.RedisPerSecondUrl, s.RedisPerSecondPoolSize, s.RedisPoolOverflowSize, s.RedisPoolOverflowDrainPeriod)
+		perSecondPool = redis.NewPoolImpl(srv.Scope().Scope("redis_per_second_pool"), s.RedisPerSecondTls, s.RedisPerSecondAuth, s.RedisPerSecondUrl, s.RedisPerSecondPoolSize, s.RedisPoolOverflowSize, s.RedisPoolOverflowDrainPeriod, s.RedisPoolMaxNewConnPerSecond)
 	}
 	var otherPool redis.Pool
-	otherPool = redis.NewPoolImpl(srv.Scope().Scope("redis_pool"), s.RedisTls, s.RedisAuth, s.RedisUrl, s.RedisPoolSize, s.RedisPoolOverflowSize, s.RedisPoolOverflowDrainPeriod)
+	otherPool = redis.NewPoolImpl(srv.Scope().Scope("redis_pool"), s.RedisTls, s.RedisAuth, s.RedisUrl, s.RedisPoolSize, s.RedisPoolOverflowSize, s.RedisPoolOverflowDrainPeriod, s.RedisPoolMaxNewConnPerSecond)
 
 	service := ratelimit.NewService(
 		srv.Runtime(),

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -27,6 +27,7 @@ type Settings struct {
 	RedisPoolOverflowSize        int           `envconfig:"REDIS_POOL_SIZE_OVERFLOW_SIZE" default:"10"`
 	RedisPoolOverflowDrainPeriod time.Duration `envconfig:"REDIS_POOL_SIZE_OVERFLOW_DRAIN_PERIOD" default:"5s"`
 	RedisPoolMaxNewConnPerSecond int           `envconfig:"REDIS_POOL_MAX_NEW_CONN_PER_SECOND" default:"1"`
+	RedisPoolGetTimeout          time.Duration `envconfig:"REDIS_POOL_GET_TIMEOUT" default:"200ms"`
 	RedisAuth                    string        `envconfig:"REDIS_AUTH" default:""`
 	RedisTls                     bool          `envconfig:"REDIS_TLS" default:"false"`
 	RedisPerSecond               bool          `envconfig:"REDIS_PERSECOND" default:"false"`

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -26,6 +26,7 @@ type Settings struct {
 	RedisPoolSize                int           `envconfig:"REDIS_POOL_SIZE" default:"10"`
 	RedisPoolOverflowSize        int           `envconfig:"REDIS_POOL_SIZE_OVERFLOW_SIZE" default:"10"`
 	RedisPoolOverflowDrainPeriod time.Duration `envconfig:"REDIS_POOL_SIZE_OVERFLOW_DRAIN_PERIOD" default:"5s"`
+	RedisPoolMaxNewConnPerSecond int           `envconfig:"REDIS_POOL_MAX_NEW_CONN_PER_SECOND" default:"1"`
 	RedisAuth                    string        `envconfig:"REDIS_AUTH" default:""`
 	RedisTls                     bool          `envconfig:"REDIS_TLS" default:"false"`
 	RedisPerSecond               bool          `envconfig:"REDIS_PERSECOND" default:"false"`


### PR DESCRIPTION
The idea that somehow creating an entire new connection to run a single command to immediately dispose of them helps with dealing with spikes is 💩.